### PR TITLE
Register uuid funcs with correct param

### DIFF
--- a/src/uuid.cc
+++ b/src/uuid.cc
@@ -690,7 +690,7 @@ void uuid_generate_v7_impl(vef_context_t* ctx, vef_vdf_result_t* result) {
   copy_uuid_to_binary_result(binary_uuid, result);
 }
 
-// UUID_VERSION(str) - extracts version number from UUID string
+// UUID_VERSION(uuid) - extracts version number from UUID value
 void uuid_version_impl(vef_context_t* ctx,
                        vef_invalue_t* arg,
                        vef_vdf_result_t* result) {
@@ -699,17 +699,11 @@ void uuid_version_impl(vef_context_t* ctx,
     return;
   }
 
-  unsigned char binary_uuid[kUuidBinarySize];
-  if (!parse_uuid_string(arg->str_value, arg->str_len, binary_uuid)) {
-    result->type = VEF_RESULT_NULL;
-    return;
-  }
-
   result->type = VEF_RESULT_VALUE;
-  result->int_value = (binary_uuid[6] >> 4) & 0x0F;
+  result->int_value = (arg->bin_value[6] >> 4) & 0x0F;
 }
 
-// UUID_TIMESTAMP(str) - extracts timestamp from v1/v6/v7 UUID as datetime string
+// UUID_TIMESTAMP(uuid) - extracts timestamp from v1/v6/v7 UUID as datetime string
 void uuid_timestamp_impl(vef_context_t* ctx,
                          vef_invalue_t* arg,
                          vef_vdf_result_t* result) {
@@ -718,12 +712,7 @@ void uuid_timestamp_impl(vef_context_t* ctx,
     return;
   }
 
-  unsigned char binary_uuid[kUuidBinarySize];
-  if (!parse_uuid_string(arg->str_value, arg->str_len, binary_uuid)) {
-    result->type = VEF_RESULT_NULL;
-    return;
-  }
-
+  const unsigned char *binary_uuid = arg->bin_value;
   int version = (binary_uuid[6] >> 4) & 0x0F;
   time_t unix_seconds;
 
@@ -803,7 +792,7 @@ void uuid_timestamp_impl(vef_context_t* ctx,
   result->actual_len = len;
 }
 
-// UUID_EPOCH(str) - extracts Unix epoch timestamp (seconds since 1970) from v1/v6/v7 UUID
+// UUID_EPOCH(uuid) - extracts Unix epoch timestamp (seconds since 1970) from v1/v6/v7 UUID
 void uuid_epoch_impl(vef_context_t* ctx,
                      vef_invalue_t* arg,
                      vef_vdf_result_t* result) {
@@ -812,12 +801,7 @@ void uuid_epoch_impl(vef_context_t* ctx,
     return;
   }
 
-  unsigned char binary_uuid[kUuidBinarySize];
-  if (!parse_uuid_string(arg->str_value, arg->str_len, binary_uuid)) {
-    result->type = VEF_RESULT_NULL;
-    return;
-  }
-
+  const unsigned char *binary_uuid = arg->bin_value;
   int version = (binary_uuid[6] >> 4) & 0x0F;
   int64_t unix_seconds;
 
@@ -878,7 +862,7 @@ void uuid_epoch_impl(vef_context_t* ctx,
   result->int_value = unix_seconds;
 }
 
-// uuid_compare(str1, str2) - compares two UUID strings, returns -1/0/1
+// uuid_compare(uuid1, uuid2) - compares two UUID values, returns -1/0/1
 void uuid_compare_impl(vef_context_t* ctx,
                        vef_invalue_t* arg1, vef_invalue_t* arg2,
                        vef_vdf_result_t* result) {
@@ -887,18 +871,7 @@ void uuid_compare_impl(vef_context_t* ctx,
     return;
   }
 
-  // Parse both UUID strings to binary
-  unsigned char binary1[kUuidBinarySize];
-  unsigned char binary2[kUuidBinarySize];
-
-  if (!parse_uuid_string(arg1->str_value, arg1->str_len, binary1) ||
-      !parse_uuid_string(arg2->str_value, arg2->str_len, binary2)) {
-    result->type = VEF_RESULT_NULL;
-    return;
-  }
-
-  // Compare the binary UUIDs
-  int cmp = memcmp(binary1, binary2, kUuidBinarySize);
+  int cmp = memcmp(arg1->bin_value, arg2->bin_value, kUuidBinarySize);
 
   result->type = VEF_RESULT_VALUE;
   result->int_value = (cmp < 0) ? -1 : (cmp > 0) ? 1 : 0;
@@ -955,23 +928,23 @@ VEF_GENERATE_ENTRY_POINTS(
     // UUID utility functions
     .func(make_func<&uuid_compare_impl>("UUID_COMPARE")
       .returns(INT)
-      .param(STRING)
-      .param(STRING)
+      .param(UUID)
+      .param(UUID)
       .build())
 
     .func(make_func<&uuid_version_impl>("UUID_VERSION")
       .returns(INT)
-      .param(STRING)
+      .param(UUID)
       .build())
 
     .func(make_func<&uuid_timestamp_impl>("UUID_TIMESTAMP")
       .returns(STRING)
-      .param(STRING)
+      .param(UUID)
       .buffer_size(20)
       .build())
 
     .func(make_func<&uuid_epoch_impl>("UUID_EPOCH")
       .returns(INT)
-      .param(STRING)
+      .param(UUID)
       .build())
 )

--- a/test/r/uuid_basic.result
+++ b/test/r/uuid_basic.result
@@ -1,102 +1,89 @@
 INSTALL EXTENSION vsql_uuid;
+CREATE TEMPORARY TABLE t_known (
+id INT PRIMARY KEY,
+uuid_val UUID,
+label VARCHAR(30)
+);
+INSERT INTO t_known VALUES
+(1,  '6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'v1_dns'),
+(3,  '45a113ac-c7f2-30b0-90a5-a399ab912716', 'v3'),
+(4,  '550e8400-e29b-41d4-a716-446655440000', 'v4'),
+(5,  '4be0643f-1d98-573b-97cd-ca98a65347dd', 'v5'),
+(6,  '1d19dad6-ba7b-6810-80b4-00c04fd430c8', 'v6_known'),
+(7,  '01901931-9c00-7000-8000-000000000000', 'v7_known'),
+(0,  '00000000-0000-0000-0000-000000000000', 'nil'),
+(15, 'ffffffff-ffff-ffff-ffff-ffffffffffff', 'max');
 #
 # Test UUID_VERSION function
 #
-SELECT UUID_VERSION('6ba7b810-9dad-11d1-80b4-00c04fd430c8') AS version_v1;
-version_v1
-1
-SELECT UUID_VERSION('45a113ac-c7f2-30b0-90a5-a399ab912716') AS version_v3;
-version_v3
-3
-SELECT UUID_VERSION('550e8400-e29b-41d4-a716-446655440000') AS version_v4;
-version_v4
-4
-SELECT UUID_VERSION('4be0643f-1d98-573b-97cd-ca98a65347dd') AS version_v5;
-version_v5
-5
-SELECT UUID_VERSION('1d19dad6-ba7b-6810-80b4-00c04fd430c8') AS version_v6_known;
-version_v6_known
-6
-SELECT UUID_VERSION('01901931-9c00-7000-8000-000000000000') AS version_v7_known;
-version_v7_known
-7
+SELECT UUID_VERSION(uuid_val) AS version, label FROM t_known ORDER BY id;
+version	label
+0	nil
+1	v1_dns
+3	v3
+4	v4
+5	v5
+6	v6_known
+7	v7_known
+15	max
 SET @v6_uuid = UUID_V6();
+SET @v7_uuid = UUID_V7();
 SELECT UUID_VERSION(@v6_uuid) AS version_v6;
 version_v6
-NULL
-SET @v7_uuid = UUID_V7();
+6
 SELECT UUID_VERSION(@v7_uuid) AS version_v7;
 version_v7
-NULL
-SELECT UUID_VERSION('00000000-0000-0000-0000-000000000000') AS version_nil;
-version_nil
-0
-SELECT UUID_VERSION('ffffffff-ffff-ffff-ffff-ffffffffffff') AS version_max;
-version_max
-15
+7
+SET @v6_uuid = NULL;
+SET @v7_uuid = NULL;
 SELECT UUID_VERSION(NULL) IS NULL AS null_version;
 null_version
 1
-SELECT UUID_VERSION('invalid-uuid') AS invalid_version;
-invalid_version
-NULL
 #
 # Test UUID_TIMESTAMP function
 #
-SELECT UUID_TIMESTAMP('6ba7b810-9dad-11d1-80b4-00c04fd430c8') AS timestamp_v1;
-timestamp_v1
-1998-02-04 22:13:53
-SELECT UUID_TIMESTAMP('1d19dad6-ba7b-6810-80b4-00c04fd430c8') AS timestamp_v6;
-timestamp_v6
-1998-02-04 22:13:53
-SELECT UUID_TIMESTAMP('01901931-9c00-7000-8000-000000000000') AS timestamp_v7;
-timestamp_v7
-2024-06-15 00:00:00
-SET @v6_uuid = NULL;
-SET @v7_uuid = NULL;
-SELECT UUID_TIMESTAMP('550e8400-e29b-41d4-a716-446655440000') AS timestamp_v4;
-timestamp_v4
-NULL
-SELECT UUID_TIMESTAMP('45a113ac-c7f2-30b0-90a5-a399ab912716') AS timestamp_v3;
-timestamp_v3
-NULL
+SELECT UUID_TIMESTAMP(uuid_val) AS ts, label
+FROM t_known
+WHERE id IN (1, 6, 7)
+ORDER BY id;
+ts	label
+1998-02-04 22:13:53	v1_dns
+1998-02-04 22:13:53	v6_known
+2024-06-15 00:00:00	v7_known
+SELECT UUID_TIMESTAMP(uuid_val) IS NULL AS no_ts, label
+FROM t_known
+WHERE id IN (3, 4, 5, 0, 15)
+ORDER BY id;
+no_ts	label
+1	nil
+1	v3
+1	v4
+1	v5
+1	max
 SELECT UUID_TIMESTAMP(NULL) IS NULL AS timestamp_null;
 timestamp_null
 1
-SELECT UUID_TIMESTAMP('invalid-uuid') AS timestamp_invalid;
-timestamp_invalid
-NULL
-SELECT UUID_TIMESTAMP('00000000-0000-0000-0000-000000000000') AS timestamp_nil;
-timestamp_nil
-NULL
-SELECT UUID_TIMESTAMP('ffffffff-ffff-ffff-ffff-ffffffffffff') AS timestamp_max;
-timestamp_max
-NULL
 #
 # Test UUID_EPOCH function
 #
-SELECT UUID_EPOCH('6ba7b810-9dad-11d1-80b4-00c04fd430c8') AS epoch_v1;
-epoch_v1
-886630433
-SELECT UUID_EPOCH('1d19dad6-ba7b-6810-80b4-00c04fd430c8') AS epoch_v6;
-epoch_v6
-886630433
-SELECT UUID_EPOCH('01901931-9c00-7000-8000-000000000000') AS epoch_v7;
-epoch_v7
-1718409600
-SELECT UUID_EPOCH('550e8400-e29b-41d4-a716-446655440000') AS epoch_v4;
-epoch_v4
-NULL
-SELECT UUID_EPOCH('00000000-0000-0000-0000-000000000000') AS epoch_nil;
-epoch_nil
-NULL
-SELECT UUID_EPOCH('ffffffff-ffff-ffff-ffff-ffffffffffff') AS epoch_max;
-epoch_max
-NULL
+SELECT UUID_EPOCH(uuid_val) AS epoch, label
+FROM t_known
+WHERE id IN (1, 6, 7)
+ORDER BY id;
+epoch	label
+886630433	v1_dns
+886630433	v6_known
+1718409600	v7_known
+SELECT UUID_EPOCH(uuid_val) IS NULL AS no_epoch, label
+FROM t_known
+WHERE id IN (4, 0, 15)
+ORDER BY id;
+no_epoch	label
+1	nil
+1	v4
+1	max
 SELECT UUID_EPOCH(NULL) IS NULL AS epoch_null;
 epoch_null
 1
-SELECT UUID_EPOCH('invalid-uuid') AS epoch_invalid;
-epoch_invalid
-NULL
+DROP TABLE t_known;
 UNINSTALL EXTENSION vsql_uuid;

--- a/test/r/uuid_compare.result
+++ b/test/r/uuid_compare.result
@@ -1,44 +1,38 @@
 INSTALL EXTENSION vsql_uuid;
+CREATE TABLE vsql_test_cmp (
+label VARCHAR(40) PRIMARY KEY,
+a UUID,
+b UUID
+);
+INSERT INTO vsql_test_cmp VALUES
+('identical',          '550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440000'),
+('min_max',            '00000000-0000-0000-0000-000000000000', 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+('max_min',            'ffffffff-ffff-ffff-ffff-ffffffffffff', '00000000-0000-0000-0000-000000000000'),
+('uuid1_lt_uuid2',     '550e8400-e29b-41d4-a716-446655440000', '6ba7b810-9dad-11d1-80b4-00c04fd430c8'),
+('uuid2_gt_uuid1',     '6ba7b810-9dad-11d1-80b4-00c04fd430c8', '550e8400-e29b-41d4-a716-446655440000'),
+('case_insensitive',   '550e8400-e29b-41d4-a716-446655440000', '550E8400-E29B-41D4-A716-446655440000'),
+('sequential_lt',      '550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440001'),
+('sequential_gt',      '550e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440000');
 #
 # Test UUID comparison functions
 #
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440000') AS identical_compare;
-identical_compare
-0
-SELECT UUID_COMPARE('00000000-0000-0000-0000-000000000000', 'ffffffff-ffff-ffff-ffff-ffffffffffff') AS min_max_compare;
-min_max_compare
--1
-SELECT UUID_COMPARE('ffffffff-ffff-ffff-ffff-ffffffffffff', '00000000-0000-0000-0000-000000000000') AS max_min_compare;
-max_min_compare
-1
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '6ba7b810-9dad-11d1-80b4-00c04fd430c8') AS uuid1_uuid2_compare;
-uuid1_uuid2_compare
--1
-SELECT UUID_COMPARE('6ba7b810-9dad-11d1-80b4-00c04fd430c8', '550e8400-e29b-41d4-a716-446655440000') AS uuid2_uuid1_compare;
-uuid2_uuid1_compare
-1
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '550E8400-E29B-41D4-A716-446655440000') AS case_insensitive_compare;
-case_insensitive_compare
-0
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440001') AS sequential_compare;
-sequential_compare
--1
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440000') AS reverse_sequential_compare;
-reverse_sequential_compare
-1
-SELECT UUID_COMPARE('invalid-uuid', '550e8400-e29b-41d4-a716-446655440000') IS NULL AS invalid_first;
-invalid_first
-0
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', 'invalid-uuid') IS NULL AS invalid_second;
-invalid_second
-0
-SELECT UUID_COMPARE('invalid-uuid', 'also-invalid') IS NULL AS both_invalid;
-both_invalid
-0
-SELECT UUID_COMPARE(NULL, '550e8400-e29b-41d4-a716-446655440000') IS NULL AS null_first;
+SELECT label, UUID_COMPARE(a, b) AS result
+FROM vsql_test_cmp
+ORDER BY label;
+label	result
+case_insensitive	0
+identical	0
+max_min	1
+min_max	-1
+sequential_gt	1
+sequential_lt	-1
+uuid1_lt_uuid2	-1
+uuid2_gt_uuid1	1
+SELECT UUID_COMPARE(NULL, a) IS NULL AS null_first FROM vsql_test_cmp WHERE label = 'identical';
 null_first
 1
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', NULL) IS NULL AS null_second;
+SELECT UUID_COMPARE(a, NULL) IS NULL AS null_second FROM vsql_test_cmp WHERE label = 'identical';
 null_second
 1
+DROP TABLE vsql_test_cmp;
 UNINSTALL EXTENSION vsql_uuid;

--- a/test/r/uuid_type.result
+++ b/test/r/uuid_type.result
@@ -36,12 +36,17 @@ case_insensitive
 SET @test_uuid = '550e8400-e29b-41d4-a716-446655440000';
 INSERT INTO uuid_test (uuid_col, name) VALUES
 (@test_uuid, 'roundtrip_conversion');
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440000') = 0 AS compare_equal;
+CREATE TABLE vsql_test_cmp_type (a UUID, b UUID);
+INSERT INTO vsql_test_cmp_type VALUES
+('550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440000'),
+('550e8400-e29b-41d4-a716-446655440000', '00000000-0000-0000-0000-000000000000');
+SELECT UUID_COMPARE(a, b) = 0 AS compare_equal FROM vsql_test_cmp_type LIMIT 1;
 compare_equal
 1
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '00000000-0000-0000-0000-000000000000') > 0 AS compare_greater;
+SELECT UUID_COMPARE(a, b) > 0 AS compare_greater FROM vsql_test_cmp_type LIMIT 1 OFFSET 1;
 compare_greater
 1
+DROP TABLE vsql_test_cmp_type;
 INSERT INTO uuid_test (uuid_col, name) VALUES
 (UUID_V3('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'test'), 'v3_generated'),
 (UUID_V5('6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'test'), 'v5_generated');

--- a/test/t/uuid_basic.test
+++ b/test/t/uuid_basic.test
@@ -7,110 +7,80 @@ if ($VSQL_UUID_VEB) {
 }
 INSTALL EXTENSION vsql_uuid;
 
+# UUID_VERSION, UUID_TIMESTAMP, and UUID_EPOCH take a uuid type.
+# Use a table column to exercise the typed-column path (the real use case).
+
+CREATE TEMPORARY TABLE t_known (
+  id INT PRIMARY KEY,
+  uuid_val UUID,
+  label VARCHAR(30)
+);
+
+INSERT INTO t_known VALUES
+  (1,  '6ba7b810-9dad-11d1-80b4-00c04fd430c8', 'v1_dns'),
+  (3,  '45a113ac-c7f2-30b0-90a5-a399ab912716', 'v3'),
+  (4,  '550e8400-e29b-41d4-a716-446655440000', 'v4'),
+  (5,  '4be0643f-1d98-573b-97cd-ca98a65347dd', 'v5'),
+  (6,  '1d19dad6-ba7b-6810-80b4-00c04fd430c8', 'v6_known'),
+  (7,  '01901931-9c00-7000-8000-000000000000', 'v7_known'),
+  (0,  '00000000-0000-0000-0000-000000000000', 'nil'),
+  (15, 'ffffffff-ffff-ffff-ffff-ffffffffffff', 'max');
+
 --echo #
 --echo # Test UUID_VERSION function
 --echo #
 
-# Test UUID_VERSION with known v1 UUID (DNS namespace)
-SELECT UUID_VERSION('6ba7b810-9dad-11d1-80b4-00c04fd430c8') AS version_v1;
+SELECT UUID_VERSION(uuid_val) AS version, label FROM t_known ORDER BY id;
 
-# Test UUID_VERSION with known v3 UUID
-SELECT UUID_VERSION('45a113ac-c7f2-30b0-90a5-a399ab912716') AS version_v3;
-
-# Test UUID_VERSION with known v4 UUID
-SELECT UUID_VERSION('550e8400-e29b-41d4-a716-446655440000') AS version_v4;
-
-# Test UUID_VERSION with known v5 UUID
-SELECT UUID_VERSION('4be0643f-1d98-573b-97cd-ca98a65347dd') AS version_v5;
-
-# Test UUID_VERSION with known v6 UUID (reordered v1 of DNS namespace UUID)
-SELECT UUID_VERSION('1d19dad6-ba7b-6810-80b4-00c04fd430c8') AS version_v6_known;
-
-# Test UUID_VERSION with known v7 UUID
-SELECT UUID_VERSION('01901931-9c00-7000-8000-000000000000') AS version_v7_known;
-
-# Test UUID_VERSION with generated v6 UUID
+# Generated UUIDs: UUID_V*() returns the uuid type directly
 SET @v6_uuid = UUID_V6();
-SELECT UUID_VERSION(@v6_uuid) AS version_v6;
-
-# Test UUID_VERSION with generated v7 UUID
 SET @v7_uuid = UUID_V7();
+SELECT UUID_VERSION(@v6_uuid) AS version_v6;
 SELECT UUID_VERSION(@v7_uuid) AS version_v7;
+SET @v6_uuid = NULL;
+SET @v7_uuid = NULL;
 
-# Test UUID_VERSION with nil UUID (version 0)
-SELECT UUID_VERSION('00000000-0000-0000-0000-000000000000') AS version_nil;
-
-# Test UUID_VERSION with max UUID (version nibble = f = 15)
-SELECT UUID_VERSION('ffffffff-ffff-ffff-ffff-ffffffffffff') AS version_max;
-
-# Test UUID_VERSION with NULL input
+# NULL input
 SELECT UUID_VERSION(NULL) IS NULL AS null_version;
-
-# Test UUID_VERSION with invalid UUID (returns 0)
-SELECT UUID_VERSION('invalid-uuid') AS invalid_version;
 
 --echo #
 --echo # Test UUID_TIMESTAMP function
 --echo #
 
-# Test UUID_TIMESTAMP with known v1 UUID (DNS namespace UUID from RFC - 1998-02-04 22:13:53 UTC)
-SELECT UUID_TIMESTAMP('6ba7b810-9dad-11d1-80b4-00c04fd430c8') AS timestamp_v1;
+# Known timestamps from t_known (v1/v6/v7 only; others return NULL)
+SELECT UUID_TIMESTAMP(uuid_val) AS ts, label
+FROM t_known
+WHERE id IN (1, 6, 7)
+ORDER BY id;
 
-# Test UUID_TIMESTAMP with known v6 UUID (same timestamp as v1 DNS namespace UUID above)
-SELECT UUID_TIMESTAMP('1d19dad6-ba7b-6810-80b4-00c04fd430c8') AS timestamp_v6;
+# Non-timestamp versions return NULL
+SELECT UUID_TIMESTAMP(uuid_val) IS NULL AS no_ts, label
+FROM t_known
+WHERE id IN (3, 4, 5, 0, 15)
+ORDER BY id;
 
-# Test UUID_TIMESTAMP with known v7 UUID (2024-06-15 00:00:00 UTC)
-SELECT UUID_TIMESTAMP('01901931-9c00-7000-8000-000000000000') AS timestamp_v7;
-
-# Release UUID-typed variables before further tests
-SET @v6_uuid = NULL;
-SET @v7_uuid = NULL;
-
-# Test UUID_TIMESTAMP with non-v1 UUID (returns NULL - not applicable)
-SELECT UUID_TIMESTAMP('550e8400-e29b-41d4-a716-446655440000') AS timestamp_v4;
-
-# Test UUID_TIMESTAMP with v3 UUID (returns empty - not applicable)
-SELECT UUID_TIMESTAMP('45a113ac-c7f2-30b0-90a5-a399ab912716') AS timestamp_v3;
-
-# Test UUID_TIMESTAMP with NULL input
+# NULL input
 SELECT UUID_TIMESTAMP(NULL) IS NULL AS timestamp_null;
-
-# Test UUID_TIMESTAMP with invalid UUID (returns empty)
-SELECT UUID_TIMESTAMP('invalid-uuid') AS timestamp_invalid;
-
-# Test UUID_TIMESTAMP with nil UUID (version 0, no timestamp)
-SELECT UUID_TIMESTAMP('00000000-0000-0000-0000-000000000000') AS timestamp_nil;
-
-# Test UUID_TIMESTAMP with max UUID (version 15, no timestamp)
-SELECT UUID_TIMESTAMP('ffffffff-ffff-ffff-ffff-ffffffffffff') AS timestamp_max;
 
 --echo #
 --echo # Test UUID_EPOCH function
 --echo #
 
-# Test UUID_EPOCH with known v1 UUID (DNS namespace UUID from RFC)
-SELECT UUID_EPOCH('6ba7b810-9dad-11d1-80b4-00c04fd430c8') AS epoch_v1;
+# Known epochs from t_known (v1/v6/v7 only; others return NULL)
+SELECT UUID_EPOCH(uuid_val) AS epoch, label
+FROM t_known
+WHERE id IN (1, 6, 7)
+ORDER BY id;
 
-# Test UUID_EPOCH with known v6 UUID (same timestamp as v1 DNS namespace UUID)
-SELECT UUID_EPOCH('1d19dad6-ba7b-6810-80b4-00c04fd430c8') AS epoch_v6;
+# Non-timestamp versions return NULL
+SELECT UUID_EPOCH(uuid_val) IS NULL AS no_epoch, label
+FROM t_known
+WHERE id IN (4, 0, 15)
+ORDER BY id;
 
-# Test UUID_EPOCH with known v7 UUID (2024-06-15 00:00:00 UTC = 1718409600)
-SELECT UUID_EPOCH('01901931-9c00-7000-8000-000000000000') AS epoch_v7;
-
-# Test UUID_EPOCH with v4 UUID (no timestamp, returns NULL)
-SELECT UUID_EPOCH('550e8400-e29b-41d4-a716-446655440000') AS epoch_v4;
-
-# Test UUID_EPOCH with nil UUID (returns NULL)
-SELECT UUID_EPOCH('00000000-0000-0000-0000-000000000000') AS epoch_nil;
-
-# Test UUID_EPOCH with max UUID (returns NULL)
-SELECT UUID_EPOCH('ffffffff-ffff-ffff-ffff-ffffffffffff') AS epoch_max;
-
-# Test UUID_EPOCH with NULL input
+# NULL input
 SELECT UUID_EPOCH(NULL) IS NULL AS epoch_null;
 
-# Test UUID_EPOCH with invalid UUID
-SELECT UUID_EPOCH('invalid-uuid') AS epoch_invalid;
-
 # Cleanup
+DROP TABLE t_known;
 UNINSTALL EXTENSION vsql_uuid;

--- a/test/t/uuid_compare.test
+++ b/test/t/uuid_compare.test
@@ -7,34 +7,38 @@ if ($VSQL_UUID_VEB) {
 }
 INSTALL EXTENSION vsql_uuid;
 
+# UUID_COMPARE takes uuid type. Store comparison pairs in a two-column table
+# so each pair can be compared in a single row scan (MySQL prohibits referencing
+# a temp table twice in the same statement).
+
+CREATE TABLE vsql_test_cmp (
+  label VARCHAR(40) PRIMARY KEY,
+  a UUID,
+  b UUID
+);
+
+INSERT INTO vsql_test_cmp VALUES
+  ('identical',          '550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440000'),
+  ('min_max',            '00000000-0000-0000-0000-000000000000', 'ffffffff-ffff-ffff-ffff-ffffffffffff'),
+  ('max_min',            'ffffffff-ffff-ffff-ffff-ffffffffffff', '00000000-0000-0000-0000-000000000000'),
+  ('uuid1_lt_uuid2',     '550e8400-e29b-41d4-a716-446655440000', '6ba7b810-9dad-11d1-80b4-00c04fd430c8'),
+  ('uuid2_gt_uuid1',     '6ba7b810-9dad-11d1-80b4-00c04fd430c8', '550e8400-e29b-41d4-a716-446655440000'),
+  ('case_insensitive',   '550e8400-e29b-41d4-a716-446655440000', '550E8400-E29B-41D4-A716-446655440000'),
+  ('sequential_lt',      '550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440001'),
+  ('sequential_gt',      '550e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440000');
+
 --echo #
 --echo # Test UUID comparison functions
 --echo #
 
-# Test uuid_compare with identical UUIDs
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440000') AS identical_compare;
+SELECT label, UUID_COMPARE(a, b) AS result
+FROM vsql_test_cmp
+ORDER BY label;
 
-# Test uuid_compare with different UUIDs (lexicographic order)
-SELECT UUID_COMPARE('00000000-0000-0000-0000-000000000000', 'ffffffff-ffff-ffff-ffff-ffffffffffff') AS min_max_compare;
-SELECT UUID_COMPARE('ffffffff-ffff-ffff-ffff-ffffffffffff', '00000000-0000-0000-0000-000000000000') AS max_min_compare;
-
-# Test uuid_compare with known ordering
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '6ba7b810-9dad-11d1-80b4-00c04fd430c8') AS uuid1_uuid2_compare;
-SELECT UUID_COMPARE('6ba7b810-9dad-11d1-80b4-00c04fd430c8', '550e8400-e29b-41d4-a716-446655440000') AS uuid2_uuid1_compare;
-
-# Test case sensitivity in comparison
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '550E8400-E29B-41D4-A716-446655440000') AS case_insensitive_compare;
-
-# Test with sequential UUIDs
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440001') AS sequential_compare;
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440000') AS reverse_sequential_compare;
-
-# Test invalid UUID comparison
-SELECT UUID_COMPARE('invalid-uuid', '550e8400-e29b-41d4-a716-446655440000') IS NULL AS invalid_first;
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', 'invalid-uuid') IS NULL AS invalid_second;
-SELECT UUID_COMPARE('invalid-uuid', 'also-invalid') IS NULL AS both_invalid;
-SELECT UUID_COMPARE(NULL, '550e8400-e29b-41d4-a716-446655440000') IS NULL AS null_first;
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', NULL) IS NULL AS null_second;
+# NULL handling
+SELECT UUID_COMPARE(NULL, a) IS NULL AS null_first FROM vsql_test_cmp WHERE label = 'identical';
+SELECT UUID_COMPARE(a, NULL) IS NULL AS null_second FROM vsql_test_cmp WHERE label = 'identical';
 
 # Cleanup
+DROP TABLE vsql_test_cmp;
 UNINSTALL EXTENSION vsql_uuid;

--- a/test/t/uuid_type.test
+++ b/test/t/uuid_type.test
@@ -42,9 +42,15 @@ SET @test_uuid = '550e8400-e29b-41d4-a716-446655440000';
 INSERT INTO uuid_test (uuid_col, name) VALUES
     (@test_uuid, 'roundtrip_conversion');
 
-# Test UUID comparison using uuid_compare function (compares string UUIDs)
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440000') = 0 AS compare_equal;
-SELECT UUID_COMPARE('550e8400-e29b-41d4-a716-446655440000', '00000000-0000-0000-0000-000000000000') > 0 AS compare_greater;
+# Test UUID comparison using uuid_compare function.
+# Use a two-column table to avoid MySQL's "can't reopen temp table" restriction.
+CREATE TABLE vsql_test_cmp_type (a UUID, b UUID);
+INSERT INTO vsql_test_cmp_type VALUES
+  ('550e8400-e29b-41d4-a716-446655440000', '550e8400-e29b-41d4-a716-446655440000'),
+  ('550e8400-e29b-41d4-a716-446655440000', '00000000-0000-0000-0000-000000000000');
+SELECT UUID_COMPARE(a, b) = 0 AS compare_equal FROM vsql_test_cmp_type LIMIT 1;
+SELECT UUID_COMPARE(a, b) > 0 AS compare_greater FROM vsql_test_cmp_type LIMIT 1 OFFSET 1;
+DROP TABLE vsql_test_cmp_type;
 
 # Test UUID type with namespace-based generation (deterministic - same inputs = same output)
 INSERT INTO uuid_test (uuid_col, name) VALUES


### PR DESCRIPTION
UUID_VERSION, UUID_TIMESTAMP, UUID_EPOCH, and UUID_COMPARE were registered with .param(STRING). Passing a uuid column caused the server to pass raw binary bytes into the string slot, which failed string parsing and returned NULL.

Changed all four to .param(UUID) and updated implementations to read arg->bin_value directly instead of parsing a string.

Reran tests.

AI=CLAUDE