### PR TITLE
ci: use extension-actions composite action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,48 +2,14 @@ name: test
 on: [pull_request, workflow_dispatch]
 
 jobs:
-  test-build:
-    name: Tests Build with ${{ matrix.vsql}}
-    strategy:
-      matrix:
-        vsql:
-          - "main"
+  build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
-      - name: Checkout villagesql-server ${{ matrix.vsql }}
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v4
+      - uses: villagesql/extension-actions/cpp@main
         with:
-          repository: villagesql/villagesql-server
-          ref: ${{ matrix.vsql }}
-          path: villagesql-server
-      - name: Checkout extension
-        uses: actions/checkout@v6
-        with:
-          path: extension
-      - name: Setup Environment
-        run: |
-          sudo apt update
-          sudo apt install -y cmake gcc make libtirpc-dev
-      - name: Build server
-        run: |
-          mkdir -p villagesql-server/build
-          cd villagesql-server/build
-          cmake .. \
-            -DWITH_ROUTER=OFF \
-            -DWITH_UNIT_TESTS=OFF \
-            -DWITHOUT_SERVER=ON
-          make -j$(nproc) sdk
-      - name: Build extension
-        run: |
-          mkdir output
-          mkdir extension/build
-          cd extension/build
-          cmake .. \
-            -DVillageSQL_BUILD_DIR=../villagesql-server/build \
-            -DVillageSQL_VEB_INSTALL_DIR=${GITHUB_WORKSPACE}/output
-          make -j$(nproc) install
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: extension-output-${{ matrix.vsql }}.zip
-          path: output/*.veb
+          extension-name: vsql_uuid
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace the manual server checkout/build steps with `villagesql/extension-actions/cpp@main`, which builds the extension and runs the MTR suite against a pre-built dev server.

- Drops ~40 lines of manual CMake/make steps
- Adds `permissions: contents: read, actions: read`
- Now actually runs tests (old workflow only built)